### PR TITLE
Fixed 2 GB file size limit in sb_send_file()

### DIFF
--- a/src/sandbird.c
+++ b/src/sandbird.c
@@ -594,7 +594,7 @@ int sb_send_header(sb_Stream *st, const char *field, const char *val) {
 int sb_send_file(sb_Stream *st, const char *filename) {
   int err;
   char buf[32];
-  size_t sz;
+  off_t sz;
   FILE *fp = NULL;
   if (st->state > STATE_SENDING_HEADER) {
     return SB_EBADSTATE;
@@ -605,8 +605,8 @@ int sb_send_file(sb_Stream *st, const char *filename) {
 
   /* Get file size and write headers */
   fseek(fp, 0, SEEK_END);
-  sz = ftell(fp);
-  sprintf(buf, "%u", (unsigned) sz);
+  sz = ftello(fp);
+  sprintf(buf, "%ju", (uintmax_t) sz);
   err = sb_send_header(st, "Content-Length", buf);
   if (err) goto fail;
   err = sb_stream_finalize_header(st);


### PR DESCRIPTION
First of all, thanks for making Sandbird available, it's the smallest and easiest to use embeddable web server that I've found. I realize there's not been much activity here in the past three years, but I hope there's someone still around to review this pull request...

So there was a problem trying to send files bigger than 2 GB. The `sb_send_file()` implementation was using `size_t` which is 32-bit, and that was causing the "Content-Length" value in the HTTP response to be truncated to 2^31. Using `off_t` instead of `size_t` fixes the issue because it's guaranteed to be 64-bit when compiled with `-D _FILE_OFFSET_BITS=64`.
